### PR TITLE
Fix for Imprecise assert

### DIFF
--- a/lib/imagery/testsuite/test_imagery_signature_management.py
+++ b/lib/imagery/testsuite/test_imagery_signature_management.py
@@ -1007,7 +1007,7 @@ class SignaturesListByTypeTestCase(TestCase):
         shutil.rmtree(sig_dir1)
         shutil.rmtree(sig_dir2)
         # There could be more sigs if this is not an empty mapset
-        self.assertTrue(ret >= 2)
+        self.assertGreaterEqual(ret, 2)
         ret_list = list(map(utils.decode, sig_list[:ret]))
         self.assertIn(golden[0], ret_list)
         self.assertIn(golden[1], ret_list)


### PR DESCRIPTION
Use a comparison-specific unittest assertion instead of `assertTrue` with a relational expression.

Best fix here: in `lib/imagery/testsuite/test_imagery_signature_management.py`, in `test_multiple_sigs_multiple_mapsets`, replace:
- `self.assertTrue(ret >= 2)`
with:
- `self.assertGreaterEqual(ret, 2)`

This keeps behavior unchanged and provides clearer failure messages (`ret` value vs expected minimum).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._