### PR TITLE
Fix for Imprecise assert

### DIFF
--- a/imagery/i.gensig/testsuite/test_i_gensig.py
+++ b/imagery/i.gensig/testsuite/test_i_gensig.py
@@ -154,7 +154,7 @@ class SuccessTest(TestCase):
         self.assertEqual(Sn.sig[2].have_color, 0)
         self.assertEqual(Sn.sig[2].npoints, 3)
         self.assertEqual(Sn.sig[2].oclass, 9)
-        self.assertTrue(abs(Sn.sig[2].mean[0] - 6.7) < 0.1)
+        self.assertLess(abs(Sn.sig[2].mean[0] - 6.7), 0.1)
         self.assertTrue(abs(Sn.sig[2].mean[1] - 8.3) < 0.1)
         self.assertTrue(abs(Sn.sig[2].var[0][0] - 0.043) < 0.01)
         self.assertTrue(abs(Sn.sig[2].var[1][1] - 0.3) < 0.1)


### PR DESCRIPTION
Use a dedicated comparison assertion instead of `assertTrue` for the `<` condition.  
Specifically in `imagery/i.gensig/testsuite/test_i_gensig.py`, line 157 should be changed from:

- `self.assertTrue(abs(Sn.sig[2].mean[0] - 6.7) < 0.1)`

to:

- `self.assertLess(abs(Sn.sig[2].mean[0] - 6.7), 0.1)`

This preserves exact logic while providing better failure diagnostics. No imports, helper methods, or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._