### PR TITLE
Fix for Imprecise assert

### DIFF
--- a/lib/imagery/testsuite/test_imagery_signature_management.py
+++ b/lib/imagery/testsuite/test_imagery_signature_management.py
@@ -985,7 +985,7 @@ class SignaturesListByTypeTestCase(TestCase):
         # As temporary mapset is not in the search path, there must be
         # at least one sig file present
         # There could be more sigs if this is not an empty mapset
-        self.assertTrue(ret >= 1)
+        self.assertGreaterEqual(ret, 1)
         ret_list = list(map(utils.decode, sig_list[:ret]))
         golden = (
             f"{rnd_sig1}@{self.rnd_mapset_name}",


### PR DESCRIPTION
Use a specific numeric comparison assertion instead of a boolean assertion on a comparison expression.

Best fix: in `lib/imagery/testsuite/test_imagery_signature_management.py`, within `test_multiple_sigs_multiple_mapsets`, replace:
- `self.assertTrue(ret >= 1)`
with:
- `self.assertGreaterEqual(ret, 1)`

This preserves behavior exactly while improving failure output (it will report both operands). No imports, helper methods, or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._