### PR TITLE
Fix for Imprecise assert

### DIFF
--- a/imagery/i.svm.train/testsuite/test_i_svm_train.py
+++ b/imagery/i.svm.train/testsuite/test_i_svm_train.py
@@ -299,7 +299,7 @@ class IOValidationTest(TestCase):
             self.assertTrue(float(R) <= 2)
             M, R = lines[1].strip().split(" ")
             self.assertTrue(float(M) > -1 and float(M) < 1)
-            self.assertTrue(float(R) <= 20)
+            self.assertLessEqual(float(R), 20)
 
     @unittest.skipIf(shutil.which("i.svm.train") is None, "i.svm.train not found.")
     def test_fail_on_empty_raster(self):


### PR DESCRIPTION
Use a specific unittest assertion for inequality checks: replace `assertTrue(a <= b)` with `assertLessEqual(a, b)`.

Best single change here:
- In `imagery/i.svm.train/testsuite/test_i_svm_train.py`, update line 302 from:
  - `self.assertTrue(float(R) <= 20)`
  to:
  - `self.assertLessEqual(float(R), 20)`

No imports or helper methods are needed because `assertLessEqual` is already available on `unittest.TestCase`/`grass.gunittest.case.TestCase`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._