### PR TITLE
Fix for Imprecise assert

### DIFF
--- a/python/grass/pygrass/vector/testsuite/test_geometry.py
+++ b/python/grass/pygrass/vector/testsuite/test_geometry.py
@@ -81,7 +81,7 @@ class PointTestCase(TestCase):
         point0 = Point(0, 0)
         point1 = Point(1, 0)
         self.assertFalse(point0 == point1)
-        self.assertFalse(point0 == (1, 0))
+        self.assertNotEqual(point0, (1, 0))
         self.assertTrue(point0 == point0)  # noqa: PLR0124 # pylint: disable=R0124
         self.assertTrue(point0 == (0, 0))
 


### PR DESCRIPTION
Use the dedicated unittest assertion method for inequality.

- **General fix:** Replace `assertFalse(a == b)` with `assertNotEqual(a, b)` (and similarly `assertTrue(a == b)` with `assertEqual(a, b)` when applicable).
- **Best fix here:** In `python/grass/pygrass/vector/testsuite/test_geometry.py`, update line 84 inside `PointTestCase.test_eq`:
  - from `self.assertFalse(point0 == (1, 0))`
  - to `self.assertNotEqual(point0, (1, 0))`
- No imports, helper methods, or dependency changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._