### PR TITLE
Fix for Imprecise assert

### DIFF
--- a/imagery/i.gensig/testsuite/test_i_gensig.py
+++ b/imagery/i.gensig/testsuite/test_i_gensig.py
@@ -156,7 +156,7 @@ class SuccessTest(TestCase):
         self.assertEqual(Sn.sig[2].oclass, 9)
         self.assertLess(abs(Sn.sig[2].mean[0] - 6.7), 0.1)
         self.assertTrue(abs(Sn.sig[2].mean[1] - 8.3) < 0.1)
-        self.assertTrue(abs(Sn.sig[2].var[0][0] - 0.043) < 0.01)
+        self.assertLess(abs(Sn.sig[2].var[0][0] - 0.043), 0.01)
         self.assertTrue(abs(Sn.sig[2].var[1][1] - 0.3) < 0.1)
 
 


### PR DESCRIPTION
Use a specific comparison assertion instead of `assertTrue` for relational checks.  
For this exact finding, replace line 159 in `imagery/i.gensig/testsuite/test_i_gensig.py`:

- From: `self.assertTrue(abs(Sn.sig[2].var[0][0] - 0.043) < 0.01)`
- To: `self.assertLess(abs(Sn.sig[2].var[0][0] - 0.043), 0.01)`

This preserves logic while improving failure messages by showing actual compared values. No imports, helper methods, or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._