### PR TITLE
Fix for Imprecise assert

### DIFF
--- a/temporal/t.rename/testsuite/test_t_rename.py
+++ b/temporal/t.rename/testsuite/test_t_rename.py
@@ -140,7 +140,7 @@ class TestRenameSTDS(TestCase):
         print(gs.read_command("t.info", type="strds", input="precip_abs6"))
 
         self.assertEqual(strds.metadata.get_description(), "This is the 3 test strds")
-        self.assertTrue("t.rename" in strds.metadata.get_command())
+        self.assertIn("t.rename", strds.metadata.get_command())
 
     def test_rename_with_overwrite(self):
         """Test renaming a space time raster dataset while overwriting
@@ -159,7 +159,7 @@ class TestRenameSTDS(TestCase):
         print(gs.read_command("t.info", type="strds", input="precip_abs2"))
 
         self.assertEqual(strds.metadata.get_description(), "This is the 1 test strds")
-        self.assertTrue("t.rename" in strds.metadata.get_command())
+        self.assertIn("t.rename", strds.metadata.get_command())
 
     def test_fail_overwrite_without_flag(self):
         """Test that renaming a space time raster dataset fails if the


### PR DESCRIPTION
Use the specific containment assertion method provided by `unittest`/`TestCase`: replace `assertTrue(<item> in <container>)` with `assertIn(<item>, <container>)`.

Best single fix in this file:
- In `temporal/t.rename/testsuite/test_t_rename.py`, update:
  - line 143: `self.assertTrue("t.rename" in strds.metadata.get_command())`
  - line 162: `self.assertTrue("t.rename" in strds.metadata.get_command())`
- Replace both with:
  - `self.assertIn("t.rename", strds.metadata.get_command())`

No imports, helper methods, or dependency changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._