### PR TITLE
Fix for Imprecise assert

### DIFF
--- a/raster/r.smooth.edgepreserve/testsuite/test_r_smooth_edgepreserve.py
+++ b/raster/r.smooth.edgepreserve/testsuite/test_r_smooth_edgepreserve.py
@@ -155,7 +155,7 @@ class SmoothingTest(TestCase):
             function="exp",
             quiet=True,
         )
-        self.assertTrue(raster_info(out_map_d)["datatype"] == "DCELL")
+        self.assertEqual(raster_info(out_map_d)["datatype"], "DCELL")
         self.assertRastersEqual(out_map_d, self.ref_exp_f, precision=0.1)
 
     def test_quad_ram(self):


### PR DESCRIPTION
Replace the boolean comparison wrapped by `assertTrue` with `assertEqual`, keeping behavior unchanged while improving failure messages.

Best targeted fix in `raster/r.smooth.edgepreserve/testsuite/test_r_smooth_edgepreserve.py`:
- In `test_exp_d_ram`, change:
  - `self.assertTrue(raster_info(out_map_d)["datatype"] == "DCELL")`
  - to `self.assertEqual(raster_info(out_map_d)["datatype"], "DCELL")`

No imports, helper methods, or additional definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._