### PR TITLE
Fix for Imprecise assert

### DIFF
--- a/lib/init/testsuite/test_grass_tmp_mapset.py
+++ b/lib/init/testsuite/test_grass_tmp_mapset.py
@@ -98,8 +98,9 @@ class TestTmpMapset(unittest.TestCase):
             [self.executable, "--tmp-mapset", self.location, "--exec", "g.proj", "-p"]
         )
         for directory in os.listdir(self.location):
-            self.assertTrue(
-                directory in self.subdirs,
+            self.assertIn(
+                directory,
+                self.subdirs,
                 msg="Directory {directory} should have been deleted".format(**locals()),
             )
 


### PR DESCRIPTION
Use a specific membership assertion instead of a boolean assertion.  
The best fix is to replace `self.assertTrue(directory in self.subdirs, ...)` with `self.assertIn(directory, self.subdirs, ...)` in `test_mapset_deleted` in `lib/init/testsuite/test_grass_tmp_mapset.py` (around line 101). No import or additional helper is needed; `assertIn` is already available from `unittest.TestCase`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._