### PR TITLE
Fix for Imprecise assert

### DIFF
--- a/python/grass/pygrass/vector/testsuite/test_geometry.py
+++ b/python/grass/pygrass/vector/testsuite/test_geometry.py
@@ -83,7 +83,7 @@ class PointTestCase(TestCase):
         self.assertFalse(point0 == point1)
         self.assertNotEqual(point0, (1, 0))
         self.assertTrue(point0 == point0)  # noqa: PLR0124 # pylint: disable=R0124
-        self.assertTrue(point0 == (0, 0))
+        self.assertEqual(point0, (0, 0))
 
     def test_repr(self):
         """Test __eq__"""


### PR DESCRIPTION
Use a specific equality assertion in place of `assertTrue` when checking equality expressions.

Best fix in this file: in `python/grass/pygrass/vector/testsuite/test_geometry.py`, within `PointTestCase.test_eq`, replace:

- `self.assertTrue(point0 == (0, 0))`

with:

- `self.assertEqual(point0, (0, 0))`

This preserves behavior while improving failure diagnostics. No imports, helper methods, or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._