### PR TITLE
Fix for Imprecise assert

### DIFF
--- a/imagery/i.gensig/testsuite/test_i_gensig.py
+++ b/imagery/i.gensig/testsuite/test_i_gensig.py
@@ -146,7 +146,7 @@ class SuccessTest(TestCase):
         self.assertEqual(Sn.sig[1].npoints, 4)
         self.assertEqual(Sn.sig[1].oclass, 6)
         self.assertTrue(abs(Sn.sig[1].mean[0] - 8.9) < 0.1)
-        self.assertTrue(abs(Sn.sig[1].mean[1] - 1.5) < 0.1)
+        self.assertLess(abs(Sn.sig[1].mean[1] - 1.5), 0.1)
         self.assertTrue(abs(Sn.sig[1].var[0][0] - 0.003) < 0.001)
         self.assertTrue(abs(Sn.sig[1].var[1][1] - 0.3) < 0.1)
         # 9


### PR DESCRIPTION
Use a comparison-specific unittest assertion instead of `assertTrue` for the numeric bound check.

Best fix here: in `imagery/i.gensig/testsuite/test_i_gensig.py`, replace line 149:

- from: `self.assertTrue(abs(Sn.sig[1].mean[1] - 1.5) < 0.1)`
- to: `self.assertLess(abs(Sn.sig[1].mean[1] - 1.5), 0.1)`

This preserves exact behavior while improving failure messages by reporting actual compared values. No imports, helper methods, or dependency changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._