### PR TITLE
Fix for Imprecise assert

### DIFF
--- a/imagery/i.svm.predict/testsuite/test_i_svm_predict.py
+++ b/imagery/i.svm.predict/testsuite/test_i_svm_predict.py
@@ -167,9 +167,9 @@ class IOValidationTest(TestCase):
         self.tmp_rasts.append(rast)
         self.assertModuleFail(isvm)
         self.assertTrue(isvm.outputs.stderr)
-        self.assertTrue(
-            "Signature band count: 2, imagery group band count: 3"
-            in isvm.outputs.stderr
+        self.assertIn(
+            "Signature band count: 2, imagery group band count: 3",
+            isvm.outputs.stderr,
         )
 
     @unittest.skipIf(shutil.which("i.svm.predict") is None, "i.svm.predict not found.")


### PR DESCRIPTION
Replace the membership check wrapped in `assertTrue` with `assertIn` in `test_semantic_label_mismatch2` in `imagery/i.svm.predict/testsuite/test_i_svm_predict.py`.

Best fix (without changing behavior):
- In the block around lines 169–173, change:
  - `self.assertTrue("Signature band count: 2, imagery group band count: 3" in isvm.outputs.stderr)`
- To:
  - `self.assertIn("Signature band count: 2, imagery group band count: 3", isvm.outputs.stderr)`

No imports, helper methods, or dependency changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._