### PR TITLE
Fix for Imprecise assert

### DIFF
--- a/imagery/i.gensig/testsuite/test_i_gensig.py
+++ b/imagery/i.gensig/testsuite/test_i_gensig.py
@@ -147,7 +147,7 @@ class SuccessTest(TestCase):
         self.assertEqual(Sn.sig[1].oclass, 6)
         self.assertTrue(abs(Sn.sig[1].mean[0] - 8.9) < 0.1)
         self.assertLess(abs(Sn.sig[1].mean[1] - 1.5), 0.1)
-        self.assertTrue(abs(Sn.sig[1].var[0][0] - 0.003) < 0.001)
+        self.assertLess(abs(Sn.sig[1].var[0][0] - 0.003), 0.001)
         self.assertTrue(abs(Sn.sig[1].var[1][1] - 0.3) < 0.1)
         # 9
         self.assertEqual(Sn.sig[2].status, 1)


### PR DESCRIPTION
Use a specific comparison assertion instead of `assertTrue` for `<` checks.

Best fix in this snippet: change line 150 from:

- `self.assertTrue(abs(Sn.sig[1].var[0][0] - 0.003) < 0.001)`

to:

- `self.assertLess(abs(Sn.sig[1].var[0][0] - 0.003), 0.001)`

This preserves behavior exactly (same computed left-hand side and same threshold) but improves failure messages. No new imports, methods, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._