### PR TITLE
Fix for Imprecise assert

### DIFF
--- a/imagery/i.gensig/testsuite/test_i_gensig.py
+++ b/imagery/i.gensig/testsuite/test_i_gensig.py
@@ -137,7 +137,7 @@ class SuccessTest(TestCase):
         self.assertEqual(Sn.sig[0].npoints, 4)
         self.assertEqual(Sn.sig[0].oclass, 1)
         self.assertTrue(abs(Sn.sig[0].mean[0] - 2.9) < 0.1)
-        self.assertTrue(abs(Sn.sig[0].mean[1] - 7.0) < 0.1)
+        self.assertLess(abs(Sn.sig[0].mean[1] - 7.0), 0.1)
         self.assertTrue(abs(Sn.sig[0].var[0][0] - 0.03) < 0.01)
         self.assertTrue(abs(Sn.sig[0].var[1][1] - 0.6) < 0.1)
         # 6


### PR DESCRIPTION
Use a comparison-specific assertion instead of `assertTrue` for relational checks.

Best fix for the reported finding: in `imagery/i.gensig/testsuite/test_i_gensig.py`, replace the single flagged line using `assertTrue(abs(...) < 0.1)` with `assertLess(abs(...), 0.1)`. This keeps the same tolerance logic and expected behavior, but gives clearer failure output (actual left and right values). No imports, helper methods, or additional definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._