### PR TITLE
Fix for Imprecise assert

### DIFF
--- a/imagery/i.svm.train/testsuite/test_i_svm_train.py
+++ b/imagery/i.svm.train/testsuite/test_i_svm_train.py
@@ -296,7 +296,7 @@ class IOValidationTest(TestCase):
             lines = rf.readlines()
             M, R = lines[0].strip().split(" ")
             self.assertTrue(float(M) > -1 and float(M) < 1)
-            self.assertTrue(float(R) <= 2)
+            self.assertLessEqual(float(R), 2)
             M, R = lines[1].strip().split(" ")
             self.assertTrue(float(M) > -1 and float(M) < 1)
             self.assertLessEqual(float(R), 20)


### PR DESCRIPTION
Use a specific unittest assertion in place of the boolean-expression assertion.

Best fix in this file is to change only line 299 in `test_rescaling`:

- Replace `self.assertTrue(float(R) <= 2)` with `self.assertLessEqual(float(R), 2)`.

This preserves existing functionality exactly (same condition), but gives clearer failure output (`actual` and `expected` values). No imports, helper methods, or additional definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._