### PR TITLE
Fix for Imprecise assert

### DIFF
--- a/imagery/i.gensig/testsuite/test_i_gensig.py
+++ b/imagery/i.gensig/testsuite/test_i_gensig.py
@@ -136,7 +136,7 @@ class SuccessTest(TestCase):
         self.assertEqual(Sn.sig[0].have_color, 0)
         self.assertEqual(Sn.sig[0].npoints, 4)
         self.assertEqual(Sn.sig[0].oclass, 1)
-        self.assertTrue(abs(Sn.sig[0].mean[0] - 2.9) < 0.1)
+        self.assertLess(abs(Sn.sig[0].mean[0] - 2.9), 0.1)
         self.assertLess(abs(Sn.sig[0].mean[1] - 7.0), 0.1)
         self.assertTrue(abs(Sn.sig[0].var[0][0] - 0.03) < 0.01)
         self.assertTrue(abs(Sn.sig[0].var[1][1] - 0.6) < 0.1)


### PR DESCRIPTION
Use a specific assertion method for relational comparisons instead of `assertTrue` with a boolean expression.

Best fix here: in `imagery/i.gensig/testsuite/test_i_gensig.py`, replace line 139:

- from: `self.assertTrue(abs(Sn.sig[0].mean[0] - 2.9) < 0.1)`
- to: `self.assertLess(abs(Sn.sig[0].mean[0] - 2.9), 0.1)`

This preserves test behavior while improving failure output by showing both operands (`abs(...)` and `0.1`) directly. No imports, new methods, or extra definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._