### PR TITLE
Fix for Imprecise assert

### DIFF
--- a/python/grass/pygrass/vector/testsuite/test_geometry_attrs.py
+++ b/python/grass/pygrass/vector/testsuite/test_geometry_attrs.py
@@ -44,7 +44,7 @@ class GeometryAttrsTestCase(TestCase):
         with self.assertRaises(ValueError) as cm:
             self.attrs["not_existing_column_name"]
 
-        self.assertTrue("not_existing_column_name" in str(cm.exception))
+        self.assertIn("not_existing_column_name", str(cm.exception))
 
     def test_setitem(self):
         """Test __setitem__ magic method"""


### PR DESCRIPTION
Use a specific containment assertion instead of a generic boolean assertion.

Best fix (without changing functionality): in `python/grass/pygrass/vector/testsuite/test_geometry_attrs.py`, update line 47 from `assertTrue("not_existing_column_name" in str(cm.exception))` to `assertIn("not_existing_column_name", str(cm.exception))`. This preserves the exact test logic while improving failure messages.

No new imports, helper methods, or dependency changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._