### PR TITLE
Fix for Imprecise assert

### DIFF
--- a/imagery/i.gensig/testsuite/test_i_gensig.py
+++ b/imagery/i.gensig/testsuite/test_i_gensig.py
@@ -139,7 +139,7 @@ class SuccessTest(TestCase):
         self.assertLess(abs(Sn.sig[0].mean[0] - 2.9), 0.1)
         self.assertLess(abs(Sn.sig[0].mean[1] - 7.0), 0.1)
         self.assertLess(abs(Sn.sig[0].var[0][0] - 0.03), 0.01)
-        self.assertTrue(abs(Sn.sig[0].var[1][1] - 0.6) < 0.1)
+        self.assertLess(abs(Sn.sig[0].var[1][1] - 0.6), 0.1)
         # 6
         self.assertEqual(Sn.sig[1].status, 1)
         self.assertEqual(Sn.sig[1].have_color, 0)


### PR DESCRIPTION
Use a specific comparison assertion instead of a boolean assertion for relational checks.

Best fix (no functionality change): in `imagery/i.gensig/testsuite/test_i_gensig.py`, replace line 142:
- from: `self.assertTrue(abs(Sn.sig[0].var[1][1] - 0.6) < 0.1)`
- to: `self.assertLess(abs(Sn.sig[0].var[1][1] - 0.6), 0.1)`

This preserves behavior while improving failure messages and aligns with nearby assertions already using `assertLess`. No imports, helpers, or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._