### PR TITLE
Fix for Suspicious unused loop iteration variable

### DIFF
--- a/scripts/r.fillnulls/r.fillnulls.py
+++ b/scripts/r.fillnulls/r.fillnulls.py
@@ -675,7 +675,7 @@ def main():
         )
         outlist = failed_list[0]
         for hole in failed_list[1:]:
-            outlist = ", " + outlist
+            outlist += ", " + hole
         gs.message(outlist)
 
     gs.message(_("Done."))


### PR DESCRIPTION
To fix this, update the loop that builds `outlist` so it uses the iteration variable and appends each failed hole/map name.  
The best minimal, behavior-preserving fix is in `scripts/r.fillnulls/r.fillnulls.py` around lines 676–679:

- Keep `outlist = failed_list[0]`.
- Change the loop body from `outlist = ", " + outlist` to `outlist += ", " + hole`.

This preserves existing logic and output style while making the message correctly include all entries from `failed_list`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._