### PR TITLE
Fix for File is not always closed

### DIFF
--- a/scripts/db.test/db.test.py
+++ b/scripts/db.test/db.test.py
@@ -46,46 +46,43 @@ def main():
     gcore.message(_("Using DB driver: %s") % dbconn["driver"])
 
     infile = os.path.join(os.environ["GISBASE"], "etc", "db.test", test_file)
-    inf = open(infile)
-
-    while True:
-        type = inf.readline()
-        if not type:
-            break
-        type = type.rstrip("\r\n")
-
-        sql = inf.readline().rstrip("\r\n")
-        sys.stdout.write(sql + "\n")
-
-        # Copy expected result to temp file
-        try:
-            if type == "X":
-                gcore.write_command("db.execute", input="-", stdin=sql + "\n")
-            else:
-                resf = open(result, "w")
-                gcore.write_command(
-                    "db.select", input="-", flags="c", stdin=sql + "\n", stdout=resf
-                )
-                resf.close()
-
-        except CalledModuleError:
-            gcore.error("EXECUTE: ******** ERROR ********")
-        else:
-            gcore.message(_("EXECUTE: OK"))
-
-        expf = open(expected, "w")
+    with open(infile) as inf:
         while True:
-            res = inf.readline().rstrip("\r\n")
-            if not res:
+            type = inf.readline()
+            if not type:
                 break
-            expf.write(res + "\n")
-        expf.close()
+            type = type.rstrip("\r\n")
 
-        if type == "S":
-            if gcore.call(["diff", result, expected]) != 0:
-                gcore.error("RESULT: ******** ERROR ********")
+            sql = inf.readline().rstrip("\r\n")
+            sys.stdout.write(sql + "\n")
+
+            # Copy expected result to temp file
+            try:
+                if type == "X":
+                    gcore.write_command("db.execute", input="-", stdin=sql + "\n")
+                else:
+                    with open(result, "w") as resf:
+                        gcore.write_command(
+                            "db.select", input="-", flags="c", stdin=sql + "\n", stdout=resf
+                        )
+
+            except CalledModuleError:
+                gcore.error("EXECUTE: ******** ERROR ********")
             else:
-                gcore.message(_("RESULT: OK"))
+                gcore.message(_("EXECUTE: OK"))
+
+            with open(expected, "w") as expf:
+                while True:
+                    res = inf.readline().rstrip("\r\n")
+                    if not res:
+                        break
+                    expf.write(res + "\n")
+
+            if type == "S":
+                if gcore.call(["diff", result, expected]) != 0:
+                    gcore.error("RESULT: ******** ERROR ********")
+                else:
+                    gcore.message(_("RESULT: OK"))
 
 
 if __name__ == "__main__":

--- a/scripts/db.test/db.test.py
+++ b/scripts/db.test/db.test.py
@@ -63,7 +63,11 @@ def main():
                 else:
                     with open(result, "w") as resf:
                         gcore.write_command(
-                            "db.select", input="-", flags="c", stdin=sql + "\n", stdout=resf
+                            "db.select",
+                            input="-",
+                            flags="c",
+                            stdin=sql + "\n",
+                            stdout=resf,
                         )
 
             except CalledModuleError:


### PR DESCRIPTION
Use Python context managers for file handling so files are always closed, regardless of exceptions.

Best fix (without changing functionality): replace manual `open()/close()` with `with open(...) as ...:` in the shown regions:
- `inf = open(infile)` and subsequent read loop
- `resf = open(result, "w") ... resf.close()`
- `expf = open(expected, "w") ... expf.close()`

This keeps behavior the same while making closure exception-safe. No new imports or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._