### PR TITLE
Fix for File is not always closed

### DIFF
--- a/scripts/d.polar/d.polar.py
+++ b/scripts/d.polar/d.polar.py
@@ -241,7 +241,7 @@ def plot_eps(psout):
             shutil.copyfileobj(inf, outf)
 
         t = string.Template(
-        """
+            """
 $EPSSCALE $EPSSCALE scale                           %% EPS-SCALE EPS-SCALE scale
 %%
 %% drawing axes

--- a/scripts/d.polar/d.polar.py
+++ b/scripts/d.polar/d.polar.py
@@ -235,14 +235,12 @@ def plot_eps(psout):
     averagedirectionlegendy = 1.85 * halfframe
 
     ##########
-    outf = open(psout, "w")
-
     prolog = os.path.join(os.environ["GISBASE"], "etc", "d.polar", "ps_defs.eps")
-    inf = open(prolog)
-    shutil.copyfileobj(inf, outf)
-    inf.close()
+    with open(psout, "w") as outf:
+        with open(prolog) as inf:
+            shutil.copyfileobj(inf, outf)
 
-    t = string.Template(
+        t = string.Template(
         """
 $EPSSCALE $EPSSCALE scale                           %% EPS-SCALE EPS-SCALE scale
 %%


### PR DESCRIPTION
Use `with open(...) as ...:` context managers so file handles are always closed, including when exceptions occur.

Best fix here (without changing behavior): in `plot_eps` in `scripts/d.polar/d.polar.py`, replace the manual open/close sequence around lines 238–243 with nested context managers:
- `with open(psout, "w") as outf:`
- inside it, `with open(prolog) as inf:`
- keep `shutil.copyfileobj(inf, outf)` unchanged.
This preserves the exact logic/output while making closure exception-safe for both files. No new imports or helper methods are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._