### PR TITLE
Fix for File is not always closed

### DIFF
--- a/scripts/i.oif/i.oif.py
+++ b/scripts/i.oif/i.oif.py
@@ -145,9 +145,8 @@ def main():
         for v, p in oif:
             sys.stdout.write(fmt % (p + (v,)))
     else:
-        outf = open(output, "w")
-        outf.writelines(fmt % (p + (v,)) for v, p in oif)
-        outf.close()
+        with open(output, "w") as outf:
+            outf.writelines(fmt % (p + (v,)) for v, p in oif)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Use a context manager for file output in `main()` so closure is guaranteed under all control-flow paths, including exceptions during writing.

Best fix (no behavior change):
- In `scripts/i.oif/i.oif.py`, replace the manual open/write/close block at lines 148–150 with:
  - `with open(output, "w") as outf:`
  - indented `outf.writelines(...)`
- No new imports or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._