### PR TITLE
Fix for File is not always closed

### DIFF
--- a/scripts/m.proj/m.proj.py
+++ b/scripts/m.proj/m.proj.py
@@ -212,8 +212,7 @@ def main():
     if coords:
         x, y = coords.split(",")
         tmpfile = gcore.tempfile()
-        with open(tmpfile, "w") as fd:
-            fd.write("%s%s%s\n" % (x, ifs, y))
+        Path(tmpfile).write_text("%s%s%s\n" % (x, ifs, y))
         inf = open(tmpfile)
     elif input == "-":
         infile = None

--- a/scripts/m.proj/m.proj.py
+++ b/scripts/m.proj/m.proj.py
@@ -212,9 +212,8 @@ def main():
     if coords:
         x, y = coords.split(",")
         tmpfile = gcore.tempfile()
-        fd = open(tmpfile, "w")
-        fd.write("%s%s%s\n" % (x, ifs, y))
-        fd.close()
+        with open(tmpfile, "w") as fd:
+            fd.write("%s%s%s\n" % (x, ifs, y))
         inf = open(tmpfile)
     elif input == "-":
         infile = None


### PR DESCRIPTION
Use a context manager (`with open(...) as fd:`) for the temporary file write block so the file is always closed, even if `write` fails. This preserves behavior and is the standard Python fix for this class of bug.

In `scripts/m.proj/m.proj.py`, in the `if coords:` block (around lines 214–217), replace the manual `open`/`write`/`close` sequence with a `with` block. No new imports or helper methods are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._