### PR TITLE
Fix for File is not always closed

### DIFF
--- a/scripts/v.import/v.import.py
+++ b/scripts/v.import/v.import.py
@@ -254,12 +254,11 @@ def main():
 
     TMPLOC = gs.append_node_pid("tmp_v_import_location")
 
-    f = open(SRCGISRC, "w")
-    f.write("MAPSET: PERMANENT\n")
-    f.write("GISDBASE: %s\n" % GISDBASE)
-    f.write("LOCATION_NAME: %s\n" % TMPLOC)
-    f.write("GUI: text\n")
-    f.close()
+    with open(SRCGISRC, "w") as f:
+        f.write("MAPSET: PERMANENT\n")
+        f.write("GISDBASE: %s\n" % GISDBASE)
+        f.write("LOCATION_NAME: %s\n" % TMPLOC)
+        f.write("GUI: text\n")
 
     # create temp location from input without import
     gs.verbose(_("Creating temporary project for <%s>...") % OGRdatasource)


### PR DESCRIPTION
Use a context manager for file writing in `scripts/v.import/v.import.py` at the block around lines 257–262.

Best fix without changing behavior:
- Replace:
  - `f = open(SRCGISRC, "w")`
  - subsequent `f.write(...)` lines
  - `f.close()`
- With:
  - `with open(SRCGISRC, "w") as f:`
  - same `f.write(...)` calls indented under the `with` block.

This preserves exact output/content and control flow while guaranteeing the file is closed on both success and exceptions. No new imports or helper methods are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._