### PR TITLE
Fix for File is not always closed

### DIFF
--- a/scripts/r.in.wms/wms_gdal_drv.py
+++ b/scripts/r.in.wms/wms_gdal_drv.py
@@ -157,9 +157,8 @@ class WMSGdalDrv(WMSBase):
         xml_file = self._createXML()
 
         # print xml file content for debug level 1
-        file = open(xml_file)
-        gs.debug("WMS request XML:\n%s" % file.read(), 1)
-        file.close()
+        with open(xml_file) as file:
+            gs.debug("WMS request XML:\n%s" % file.read(), 1)
 
         if self.proxy:
             gdal.SetConfigOption("GDAL_HTTP_PROXY", str(self.proxy))


### PR DESCRIPTION
Use a context manager when opening `xml_file` in `_download()`.

Best fix (without changing functionality): replace the manual open/read/close sequence at lines 160–162 with:

- `with open(xml_file) as file:`
- keep the same debug call inside the block.

This preserves behavior (still reads and logs file content) while ensuring the file is always closed even if an exception is raised.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._