### PR TITLE
Potential fix for code scanning alert no. 153: Incomplete URL substring sanitization

### DIFF
--- a/utils/generate_release_notes.py
+++ b/utils/generate_release_notes.py
@@ -286,14 +286,16 @@ def notes_from_git_log(start_tag, end_tag, categories, exclude):
     lines = []
     unknow_authors = []
     for commit in commits:
-        if commit["author_email"].endswith("users.noreply.github.com"):
-            github_name = commit["author_email"].split("@")[0]
+        author_email = commit["author_email"]
+        local_part, sep, domain = author_email.rpartition("@")
+        if sep and domain == "users.noreply.github.com" and local_part:
+            github_name = local_part
             if "+" in github_name:
-                github_name = github_name.split("+")[1]
+                github_name = github_name.split("+", 1)[1]
             github_name = f"@{github_name}"
         else:
             # Emails are stored with @ replaced by a space.
-            email = commit["author_email"].replace("@", " ")
+            email = author_email.replace("@", " ")
             git_author = f"{commit['author_name']} <{email}>"
             if git_author in github_name_by_git_author:
                 github_name = github_name_by_git_author[git_author]


### PR DESCRIPTION
Potential fix for [https://github.com/echoix-org/grass/security/code-scanning/153](https://github.com/echoix-org/grass/security/code-scanning/153)

Use structured validation for the email instead of a plain suffix check.  
Best fix: parse `author_email` into local-part and domain (split once on `@`), require the domain to be exactly `users.noreply.github.com`, and only then extract the GitHub username from the local-part (`id+login` or `login`). If parsing/validation fails, fall back to the existing non-noreply mapping path.

In `utils/generate_release_notes.py`, replace the `endswith("users.noreply.github.com")` branch in `notes_from_git_log` with exact domain validation logic. No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
