### PR TITLE
Fix for File is not always closed

### DIFF
--- a/python/grass/temporal/stds_import.py
+++ b/python/grass/temporal/stds_import.py
@@ -430,7 +430,9 @@ def import_stds(
                     "id": mapid,
                     "start": line_list[1].strip(),
                     "end": line_list[2].strip(),
-                    "semantic_label": line_list[3].strip() if len(line_list) == 4 else "",
+                    "semantic_label": line_list[3].strip()
+                    if len(line_list) == 4
+                    else "",
                 }
 
                 new_list_file.write(

--- a/python/grass/temporal/stds_import.py
+++ b/python/grass/temporal/stds_import.py
@@ -391,56 +391,53 @@ def import_stds(
         fs = "|"
         maplist = []
         mapset = get_current_mapset()
-        list_file = open(list_file_name)
-        new_list_file = open(new_list_file_name, "w")
+        with open(list_file_name) as list_file, open(new_list_file_name, "w") as new_list_file:
 
-        # get number of lines to correctly form the suffix
-        max_count = -1
-        for max_count, l in enumerate(list_file):
-            pass
-        max_count += 1
-        list_file.seek(0)
+            # get number of lines to correctly form the suffix
+            max_count = -1
+            for max_count, l in enumerate(list_file):
+                pass
+            max_count += 1
+            list_file.seek(0)
 
-        # Read the map list from file
-        line_count = 0
-        while True:
-            line = list_file.readline()
-            if not line:
-                break
+            # Read the map list from file
+            line_count = 0
+            while True:
+                line = list_file.readline()
+                if not line:
+                    break
 
-            line_list = line.split(fs)
+                line_list = line.split(fs)
 
-            # The filename is actually the base name of the map
-            # that must be extended by the file suffix
-            filename = line_list[0].strip().split(":")[0]
-            if base:
-                mapname = "%s_%s" % (
-                    base,
-                    gs.get_num_suffix(line_count + 1, max_count),
+                # The filename is actually the base name of the map
+                # that must be extended by the file suffix
+                filename = line_list[0].strip().split(":")[0]
+                if base:
+                    mapname = "%s_%s" % (
+                        base,
+                        gs.get_num_suffix(line_count + 1, max_count),
+                    )
+                    mapid = "%s@%s" % (mapname, mapset)
+                else:
+                    mapname = filename
+                    mapid = mapname + "@" + mapset
+
+                row = {
+                    "filename": filename,
+                    "name": mapname,
+                    "id": mapid,
+                    "start": line_list[1].strip(),
+                    "end": line_list[2].strip(),
+                    "semantic_label": line_list[3].strip() if len(line_list) == 4 else "",
+                }
+
+                new_list_file.write(
+                    f"{mapname}{fs}{row['start']}{fs}{row['end']}"
+                    f"{fs}{row['semantic_label']}\n"
                 )
-                mapid = "%s@%s" % (mapname, mapset)
-            else:
-                mapname = filename
-                mapid = mapname + "@" + mapset
 
-            row = {
-                "filename": filename,
-                "name": mapname,
-                "id": mapid,
-                "start": line_list[1].strip(),
-                "end": line_list[2].strip(),
-                "semantic_label": line_list[3].strip() if len(line_list) == 4 else "",
-            }
-
-            new_list_file.write(
-                f"{mapname}{fs}{row['start']}{fs}{row['end']}"
-                f"{fs}{row['semantic_label']}\n"
-            )
-
-            maplist.append(row)
-            line_count += 1
-
-        list_file.close()
+                maplist.append(row)
+                line_count += 1
         new_list_file.close()
 
         # Read the init file

--- a/python/grass/temporal/stds_import.py
+++ b/python/grass/temporal/stds_import.py
@@ -391,8 +391,10 @@ def import_stds(
         fs = "|"
         maplist = []
         mapset = get_current_mapset()
-        with open(list_file_name) as list_file, open(new_list_file_name, "w") as new_list_file:
-
+        with (
+            open(list_file_name) as list_file,
+            open(new_list_file_name, "w") as new_list_file,
+        ):
             # get number of lines to correctly form the suffix
             max_count = -1
             for max_count, l in enumerate(list_file):


### PR DESCRIPTION
Use context managers for both file handles in the block that reads `list_file_name` and writes `new_list_file_name`.

Best fix (without changing behavior): replace:
- `list_file = open(list_file_name)`
- `new_list_file = open(new_list_file_name, "w")`
- manual `list_file.close()`

with a single `with open(...) as list_file, open(...) as new_list_file:` block and indent the existing read/write logic under it. This preserves existing logic and guarantees both files are closed even if an exception is raised mid-processing.

Edit region: `python/grass/temporal/stds_import.py` around current lines 394–443.

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._